### PR TITLE
ci(jenkins): enable benchmark skeleton

### DIFF
--- a/.ci/linux/benchmark.sh
+++ b/.ci/linux/benchmark.sh
@@ -4,4 +4,5 @@
 #
 set -euxo pipefail
 
-echo 'TBD'
+cd ./test/Elastic.Apm.PerfTests
+dotnet run -c Release --filter AspNetCoreLoadTestWithAgent AspNetCoreLoadTestWithoutAgent

--- a/.ci/linux/benchmark.sh
+++ b/.ci/linux/benchmark.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+#
+# This script runs the benchamarks
+#
+set -euxo pipefail
+
+echo 'TBD'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
     OPBEANS_REPO = 'opbeans-dotnet'
-    DOCKER_ELASTIC_SECRET = 'secret/apm-team/ci/docker-registry/prod'
+    BENCHMARK_SECRET  = 'secret/apm-team/ci/benchmark-cloud'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -362,7 +362,9 @@ pipeline {
                     branch 'master'
                     tag pattern: 'v\\d+\\.\\d+\\.\\d+.*', comparator: 'REGEXP'
                     expression { return params.Run_As_Master_Branch }
-                    expression { return env.BENCHMARK_UPDATED != "false" }
+                    // TODO: It's required to configure the benchmark for dotnet to be dryRun
+                    // or prepare an ES where to send the data to
+                    // expression { return env.BENCHMARK_UPDATED != "false" }
                   }
                   expression { return env.ONLY_DOCS == "false" }
                 }
@@ -371,21 +373,16 @@ pipeline {
                 withGithubNotify(context: 'Benchmarks') {
                   deleteDir()
                   unstash 'source'
-                  unstash 'cache'
-                  dockerLogin(secret: "${DOCKER_ELASTIC_SECRET}", registry: 'docker.elastic.co')
                   dir("${BASE_DIR}") {
-                    sh 'echo TBD'
+                    sendBenchmarks.prepareAndRun(secret: env.BENCHMARK_SECRET, url_var: 'ES_URL',
+                                                 user_var: 'ES_USER', pass_var: 'ES_PASS') {
+                      sh '.ci/linux/benchmark.sh'
+                    }
                   }
                 }
               }
               post {
                 always {
-                  catchError(message: 'sendBenchmarks failed', buildResult: 'FAILURE') {
-                    log(level: 'INFO', text: "sendBenchmarks is ${env.CHANGE_ID?.trim() ? 'not enabled for PRs' : 'enabled for branches'}")
-                    whenTrue(env.CHANGE_ID == null){
-                      sendBenchmarks(file: "${BASE_DIR}/${env.REPORT_FILE}", index: 'benchmark-dotnet')
-                    }
-                  }
                   catchError(message: 'deleteDir failed', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
                     deleteDir()
                   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,7 @@ pipeline {
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
     OPBEANS_REPO = 'opbeans-dotnet'
+    DOCKER_ELASTIC_SECRET = 'secret/apm-team/ci/docker-registry/prod'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -45,6 +46,12 @@ pipeline {
               dir("${BASE_DIR}"){
                 // Skip all the stages except docs for PR's with asciidoc and md changes only
                 env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true)
+
+                 // Look for changes related to the benchmark, if so then set the env variable.
+                def patternList = [
+                  '^test/Elastic.Apm.PerfTests/.*'
+                ]
+                env.BENCHMARK_UPDATED = isGitRegionMatch(patterns: patternList)
               }
             }
           }
@@ -341,6 +348,48 @@ pipeline {
                                     string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                                     string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
                 githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
+              }
+            }
+            stage('Benchmarks') {
+              agent { label 'metal' }
+              environment {
+                REPORT_FILE = 'apm-agent-benchmark-results.json'
+              }
+              when {
+                beforeAgent true
+                allOf {
+                  anyOf {
+                    branch 'master'
+                    tag pattern: 'v\\d+\\.\\d+\\.\\d+.*', comparator: 'REGEXP'
+                    expression { return params.Run_As_Master_Branch }
+                    expression { return env.BENCHMARK_UPDATED != "false" }
+                  }
+                  expression { return env.ONLY_DOCS == "false" }
+                }
+              }
+              steps {
+                withGithubNotify(context: 'Benchmarks') {
+                  deleteDir()
+                  unstash 'source'
+                  unstash 'cache'
+                  dockerLogin(secret: "${DOCKER_ELASTIC_SECRET}", registry: 'docker.elastic.co')
+                  dir("${BASE_DIR}") {
+                    sh 'echo TBD'
+                  }
+                }
+              }
+              post {
+                always {
+                  catchError(message: 'sendBenchmarks failed', buildResult: 'FAILURE') {
+                    log(level: 'INFO', text: "sendBenchmarks is ${env.CHANGE_ID?.trim() ? 'not enabled for PRs' : 'enabled for branches'}")
+                    whenTrue(env.CHANGE_ID == null){
+                      sendBenchmarks(file: "${BASE_DIR}/${env.REPORT_FILE}", index: 'benchmark-dotnet')
+                    }
+                  }
+                  catchError(message: 'deleteDir failed', buildResult: 'SUCCESS', stageResult: 'UNSTABLE') {
+                    deleteDir()
+                  }
+                }
               }
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -351,7 +351,9 @@ pipeline {
               }
             }
             stage('Benchmarks') {
-              agent { label 'metal' }
+              // agent { label 'metal' }
+              // TODO: tools are only installed in this worker for now
+              agent { label 'worker-854309' }
               environment {
                 REPORT_FILE = 'apm-agent-benchmark-results.json'
               }


### PR DESCRIPTION
This particular changes in the pipeline do nothing from the benchmarking point of view but adding a new stage with the below conditions:

- run a metal worker.
- When running from a master branch
- When running from tag branch with the format `v\\d+\\.\\d+\\.\\d+.*`
- Will be skipped if docs change only.


### Env variables to be used:
- ES_URL
- ES_USER
- ES_PASS

### Follow-ups
- [x] Enable the benchmark script to be used
- [ ] Will run the benchmark stage without pushing the data to the ES cluster for the PRs that change any files under the folder `test/Elastic.Apm.PerfTests`. Disabled for the time being.
